### PR TITLE
Allow custom ID for Rating component

### DIFF
--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -7,11 +7,15 @@ interface RatingProps {
   updateValue: (newValue: number) => void;
 }
 
-export const Rating: FC<RatingProps> = ({ id, value, updateValue }) => {
+export const Rating: FC<RatingProps> = ({
+  id = '#/properties/rating',
+  value,
+  updateValue,
+}) => {
   const [hoverAt, setHoverAt] = useState<number | null>(null);
 
   return (
-    <div id="#/properties/rating" className="rating">
+    <div id={id} className="rating">
       <InputLabel shrink style={{ marginTop: '0.8em' }}>
         Rating
       </InputLabel>


### PR DESCRIPTION
## Summary
- make the `Rating` component div id configurable with a default

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9aa547d88321bfdfa6b8afa6c941