### PR TITLE
Add Task type to JsonFormsDemo

### DIFF
--- a/src/components/JsonFormsDemo.tsx
+++ b/src/components/JsonFormsDemo.tsx
@@ -11,6 +11,7 @@ import RatingControl from './RatingControl';
 import ratingControlTester from '../ratingControlTester';
 import schema from '../schema.json';
 import uischema from '../uischema.json';
+import { Task } from '../types/Task';
 
 const classes = {
   container: {
@@ -38,7 +39,7 @@ const classes = {
   },
 };
 
-const initialData = {
+const initialData: Task = {
   name: 'Send email to Adrian',
   description: 'Confirm if you have passed the subject\nHereby ...',
   done: true,
@@ -53,7 +54,7 @@ const renderers = [
 ];
 
 export const JsonFormsDemo: FC = () => {
-  const [data, setData] = useState<object>(initialData);
+  const [data, setData] = useState<Task>(initialData);
   const stringifiedData = useMemo(() => JSON.stringify(data, null, 2), [data]);
 
   const clearData = () => {

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -1,0 +1,9 @@
+export interface Task {
+  name?: string;
+  description?: string;
+  done?: boolean;
+  due_date?: string;
+  rating?: number;
+  recurrence?: string;
+  recurrence_interval?: number;
+}


### PR DESCRIPTION
## Summary
- define a `Task` interface
- use `Task` with `useState` in `JsonFormsDemo`

## Testing
- `npm run build` *(fails: Cannot find modules)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9b4a08b08321a9bc1b50620d2514