### PR TITLE
Improve rating accessibility

### DIFF
--- a/cypress/e2e/test_form.cy.js
+++ b/cypress/e2e/test_form.cy.js
@@ -40,6 +40,20 @@ context('Form', () => {
       });
   });
 
+  it('should allow setting rating via keyboard', () => {
+    cy.get('[id="#/properties/rating"] span:last')
+      .focus()
+      .trigger('keydown', { key: 'Enter' });
+
+    cy.get('[id="boundData"]')
+      .invoke('text')
+      .then(content => {
+        const data = JSON.parse(content);
+
+        expect(data.rating).to.equal(5);
+      });
+  });
+
   it('should show errors', () => {
     cy.get('[id="#/properties/name-input"]').clear();
 

--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -25,9 +25,19 @@ export const Rating: FC<RatingProps> = ({
 
           return (
             <span
+              role="button"
+              tabIndex={0}
+              aria-label={`Set rating to ${i + 1}`}
+              aria-valuenow={i + 1}
               onMouseOver={() => setHoverAt(i + 1)}
               onMouseOut={() => setHoverAt(null)}
               onClick={() => updateValue(i + 1)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  updateValue(i + 1);
+                }
+              }}
               key={`${id}_${i}`}>
               {i < fullStars ? '\u2605' : '\u2606'}
             </span>


### PR DESCRIPTION
## Summary
- add aria attributes and keyboard handling for star rating
- test keyboard rating interaction

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run cypress:run` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9def50c48321a712f3bf13ec8419