### PR TITLE
Add basic JSON Forms designer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
 # JSON Forms React seed App
 
-This seed demonstrates how to use [JSON Forms](https://jsonforms.io) with React in order to render a simple form for displaying a task entity.
+This project demonstrates a small **JSON Forms Designer** built with React and Vite. It allows editing a JSON schema and UI schema side by side while a live preview renders the resulting form.
 
-It is based on `create-react-app` and only contains minor modifications.
+It was originally based on `create-react-app` but has been migrated to Vite.
 This project requires **Node.js 20** to run the tooling and tests.
 
 - Execute `npm ci` to install the prerequisites. If you want to have the latest released versions use `npm install`.
 - Execute `npm run build` to build the application.
 - Execute `npm start` to start the application.
 
-Browse to http://localhost:3000 to see the application in action.
+Browse to http://localhost:3000 to see the designer in action.
 
 ## File Structure
 
-Let's briefly have a look at the most important files:
+Important files:
 
-- `src/schema.json` contains the JSON schema (also referred to as 'data schema')
-- `src/uischema.json` contains the UI schema
-- `src/main.tsx` is the entry point of the application. We also customize the Material UI theme to give each control more space.
-- `src/App.tsx` is the main app component and makes use of the `JsonForms` component in order to render a form.
+- `src/context/DesignerContext.tsx` – holds the designer state
+- `src/components/*` – UI building blocks like editors, preview pane and sidebar
+- `src/utils/` – helper utilities
+
+## Usage
+
+Run `npm start` and open the application. Use the sidebar to import or export schemas
+and to load predefined templates. Edit the JSON Schema or UI Schema in the editors
+and watch the preview update instantly.
 
 The [data schema](src/schema.json) defines the structure of a Task: it contains attributes such as title, description, due date and so on.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "@mui/lab": "6.0.0-beta.22",
     "@mui/material": "^6.1.0",
     "@mui/x-date-pickers": "^7.17.0",
+    "@heroicons/react": "^2.0.18",
+    "@monaco-editor/react": "^5.0.0",
+    "classnames": "^2.3.3",
+    "react-split-pane-next": "^3.0.5",
+    "@dnd-kit/core": "^7.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -34,3 +34,28 @@ html {
     transform: rotate(360deg);
   }
 }
+.pane {
+  height: 100%;
+}
+.sidebar {
+  padding: 1rem;
+}
+.preview-pane {
+  padding: 1rem;
+}
+.status-bar {
+  padding: 0.5rem;
+  background: #eee;
+  text-align: right;
+}
+.schema-tabs {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.schema-tabs > div:first-child {
+  padding: 0.5rem;
+}
+.schema-tabs button {
+  margin-right: 0.5rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
 import './App.css';
-import { Header } from './components/Header';
-import { JsonFormsDemo } from './components/JsonFormsDemo';
+import DesignerLayout from './components/DesignerLayout';
+import { DesignerProvider } from './context/DesignerContext';
+import { templates } from './context/templates';
 
 const App = () => {
+  const initial = templates[0];
   return (
-    <>
-      <Header />
-      <JsonFormsDemo />
-    </>
+    <DesignerProvider initialSchema={initial.schema as any} initialUiSchema={initial.uiSchema as any}>
+      <DesignerLayout />
+    </DesignerProvider>
   );
 };
 

--- a/src/components/DesignerLayout.tsx
+++ b/src/components/DesignerLayout.tsx
@@ -1,0 +1,24 @@
+import SplitPane from 'react-split-pane-next';
+import Sidebar from './Sidebar';
+import PreviewPane from './PreviewPane';
+import SchemaTabs from './SchemaTabs';
+import StatusBar from './StatusBar';
+
+const DesignerLayout = () => {
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div style={{ flex: 1 }}>
+        <SplitPane split="vertical" minSize={150} defaultSize={200} className="pane">
+          <Sidebar />
+          <SplitPane split="vertical" minSize={200} defaultSize={600}>
+            <SchemaTabs />
+            <PreviewPane />
+          </SplitPane>
+        </SplitPane>
+      </div>
+      <StatusBar />
+    </div>
+  );
+};
+
+export default DesignerLayout;

--- a/src/components/ImportExport.tsx
+++ b/src/components/ImportExport.tsx
@@ -1,0 +1,30 @@
+import { useDesigner } from '../context/DesignerContext';
+import { downloadJson } from '../utils/download';
+
+const ImportExport = () => {
+  const { schema, uiSchema, setSchema, setUiSchema } = useDesigner();
+
+  const importFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file.text().then((text) => {
+      try {
+        const json = JSON.parse(text);
+        if (json.schema) setSchema(json.schema);
+        if (json.uiSchema) setUiSchema(json.uiSchema);
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  };
+
+  return (
+    <div>
+      <input type="file" accept="application/json" onChange={importFile} />
+      <button onClick={() => downloadJson('schema.json', schema)}>Export Schema</button>
+      <button onClick={() => downloadJson('uischema.json', uiSchema)}>Export UI</button>
+    </div>
+  );
+};
+
+export default ImportExport;

--- a/src/components/JsonSchemaEditor.tsx
+++ b/src/components/JsonSchemaEditor.tsx
@@ -1,0 +1,25 @@
+import Editor from '@monaco-editor/react';
+import { useDesigner } from '../context/DesignerContext';
+
+const JsonSchemaEditor = () => {
+  const { schema, setSchema } = useDesigner();
+  const handleChange = (value?: string) => {
+    if (!value) return;
+    try {
+      setSchema(JSON.parse(value));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Editor
+      height="100%"
+      defaultLanguage="json"
+      value={JSON.stringify(schema, null, 2)}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default JsonSchemaEditor;

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -1,0 +1,21 @@
+import { JsonForms } from '@jsonforms/react';
+import { materialRenderers, materialCells } from '@jsonforms/material-renderers';
+import { useDesigner } from '../context/DesignerContext';
+
+const PreviewPane = () => {
+  const { schema, uiSchema, formData, setFormData } = useDesigner();
+  return (
+    <div className="preview-pane">
+      <JsonForms
+        schema={schema as any}
+        uischema={uiSchema as any}
+        data={formData}
+        renderers={materialRenderers}
+        cells={materialCells}
+        onChange={({ data }) => setFormData(data)}
+      />
+    </div>
+  );
+};
+
+export default PreviewPane;

--- a/src/components/SchemaTabs.tsx
+++ b/src/components/SchemaTabs.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import JsonSchemaEditor from './JsonSchemaEditor';
+import UiSchemaEditor from './UiSchemaEditor';
+
+const SchemaTabs = () => {
+  const [tab, setTab] = useState<'json' | 'ui'>('json');
+  return (
+    <div className="schema-tabs" style={{ height: '100%' }}>
+      <div>
+        <button onClick={() => setTab('json')}>JSON Schema</button>
+        <button onClick={() => setTab('ui')}>UI Schema</button>
+      </div>
+      <div style={{ height: '100%' }}>{tab === 'json' ? <JsonSchemaEditor /> : <UiSchemaEditor />}</div>
+    </div>
+  );
+};
+
+export default SchemaTabs;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import TemplateModal from './TemplateModal';
+import ImportExport from './ImportExport';
+
+const Sidebar = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="sidebar">
+      <button onClick={() => setOpen(true)}>Templates</button>
+      <ImportExport />
+      <TemplateModal open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,23 @@
+import { useDesigner } from '../context/DesignerContext';
+import { validate } from '../utils/validate';
+import { useEffect, useState } from 'react';
+
+const StatusBar = () => {
+  const { schema, formData } = useDesigner();
+  const [valid, setValid] = useState(true);
+  const [errorCount, setErrorCount] = useState(0);
+
+  useEffect(() => {
+    const result = validate(schema as any, formData);
+    setValid(result.valid);
+    setErrorCount(result.errors.length);
+  }, [schema, formData]);
+
+  return (
+    <div className="status-bar">
+      {valid ? '✔ Valid' : `✖ ${errorCount} errors`}
+    </div>
+  );
+};
+
+export default StatusBar;

--- a/src/components/TemplateModal.tsx
+++ b/src/components/TemplateModal.tsx
@@ -1,0 +1,34 @@
+import { templates } from '../context/templates';
+import { useDesigner } from '../context/DesignerContext';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const TemplateModal = ({ open, onClose }: Props) => {
+  const { setSchema, setUiSchema } = useDesigner();
+  if (!open) return null;
+  return (
+    <div className="modal">
+      <h2>Select Template</h2>
+      <ul>
+        {templates.map((t) => (
+          <li key={t.name}>
+            <button
+              onClick={() => {
+                setSchema(t.schema as any);
+                setUiSchema(t.uiSchema as any);
+                onClose();
+              }}>
+              {t.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={onClose}>Close</button>
+    </div>
+  );
+};
+
+export default TemplateModal;

--- a/src/components/UiSchemaEditor.tsx
+++ b/src/components/UiSchemaEditor.tsx
@@ -1,0 +1,25 @@
+import Editor from '@monaco-editor/react';
+import { useDesigner } from '../context/DesignerContext';
+
+const UiSchemaEditor = () => {
+  const { uiSchema, setUiSchema } = useDesigner();
+  const handleChange = (value?: string) => {
+    if (!value) return;
+    try {
+      setUiSchema(JSON.parse(value));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Editor
+      height="100%"
+      defaultLanguage="json"
+      value={JSON.stringify(uiSchema, null, 2)}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default UiSchemaEditor;

--- a/src/context/DesignerContext.tsx
+++ b/src/context/DesignerContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { JsonSchema7 } from '@jsonforms/core';
+import { UISchemaElement } from '@jsonforms/core';
+
+export interface DesignerState {
+  schema: JsonSchema7;
+  uiSchema: UISchemaElement;
+  formData: any;
+  errors: any[];
+}
+
+interface DesignerContextProps extends DesignerState {
+  setSchema: (schema: JsonSchema7) => void;
+  setUiSchema: (uiSchema: UISchemaElement) => void;
+  setFormData: (data: any) => void;
+}
+
+const DesignerContext = createContext<DesignerContextProps | undefined>(undefined);
+
+export const useDesigner = () => {
+  const ctx = useContext(DesignerContext);
+  if (!ctx) throw new Error('DesignerContext missing');
+  return ctx;
+};
+
+interface ProviderProps {
+  children: ReactNode;
+  initialSchema: JsonSchema7;
+  initialUiSchema: UISchemaElement;
+}
+
+export const DesignerProvider = ({ children, initialSchema, initialUiSchema }: ProviderProps) => {
+  const [schema, setSchema] = useState<JsonSchema7>(initialSchema);
+  const [uiSchema, setUiSchema] = useState<UISchemaElement>(initialUiSchema);
+  const [formData, setFormData] = useState<any>({});
+  const [errors, setErrors] = useState<any[]>([]);
+
+  return (
+    <DesignerContext.Provider
+      value={{ schema, uiSchema, formData, errors, setSchema, setUiSchema, setFormData }}>
+      {children}
+    </DesignerContext.Provider>
+  );
+};

--- a/src/context/templates.ts
+++ b/src/context/templates.ts
@@ -1,0 +1,21 @@
+export const templates = [
+  {
+    name: 'Task',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', title: 'Name' },
+        description: { type: 'string', title: 'Description' },
+        done: { type: 'boolean', title: 'Done' },
+      },
+    },
+    uiSchema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/name' },
+        { type: 'Control', scope: '#/properties/description' },
+        { type: 'Control', scope: '#/properties/done' },
+      ],
+    },
+  },
+];

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,11 @@
+export const downloadJson = (filename: string, data: any) => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,13 @@
+import Ajv from 'ajv';
+import { JsonSchema7, UISchemaElement } from '@jsonforms/core';
+
+const ajv = new Ajv({ allErrors: true });
+
+export const validate = (schema: JsonSchema7, data: any) => {
+  const validateFn = ajv.compile(schema);
+  const valid = validateFn(data);
+  return {
+    valid: !!valid,
+    errors: validateFn.errors || [],
+  };
+};


### PR DESCRIPTION
## Summary
- add designer context and templates
- add utilities for download and validation
- create JSON editors, preview pane and layout
- add sidebar with template import/export controls
- integrate new designer into app
- update README with designer instructions
- include new dependencies for editor and split pane

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea477424c8321acf34a6cf875f5de