### PR TITLE
Add draggable controls with dnd-kit placeholder

### DIFF
--- a/src/components/DesignerLayout.tsx
+++ b/src/components/DesignerLayout.tsx
@@ -8,9 +8,14 @@ const DesignerLayout = () => {
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <div style={{ flex: 1 }}>
-        <SplitPane split="vertical" minSize={150} defaultSize={200} className="pane">
+        <SplitPane
+          split="vertical"
+          minSize={150}
+          defaultSize={200}
+          className="pane">
           <Sidebar />
           <SplitPane split="vertical" minSize={200} defaultSize={600}>
+            {/* TODO designate this area as a drop zone for controls */}
             <SchemaTabs />
             <PreviewPane />
           </SplitPane>

--- a/src/components/DraggableControls.tsx
+++ b/src/components/DraggableControls.tsx
@@ -1,0 +1,28 @@
+import { useDraggable } from '@dnd-kit/core';
+
+const controls = ['Control', 'VerticalLayout', 'HorizontalLayout'];
+
+const DraggableControl = ({ type }: { type: string }) => {
+  // TODO connect useDraggable to enable drag behavior
+  const { attributes, listeners, setNodeRef } = useDraggable({ id: type });
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className="draggable-control">
+      {type}
+    </div>
+  );
+};
+
+const DraggableControls = () => (
+  <div className="draggable-controls">
+    {/* TODO render additional controls for drag-and-drop */}
+    {controls.map(type => (
+      <DraggableControl key={type} type={type} />
+    ))}
+  </div>
+);
+
+export default DraggableControls;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 import TemplateModal from './TemplateModal';
 import ImportExport from './ImportExport';
+import DraggableControls from './DraggableControls';
 
 const Sidebar = () => {
   const [open, setOpen] = useState(false);
   return (
     <div className="sidebar">
       <button onClick={() => setOpen(true)}>Templates</button>
+      {/* TODO integrate DraggableControls with drop targets */}
+      <DraggableControls />
       <ImportExport />
       <TemplateModal open={open} onClose={() => setOpen(false)} />
     </div>


### PR DESCRIPTION
## Summary
- add basic draggable controls component utilizing `@dnd-kit/core`
- wire up draggable controls in `Sidebar`
- mark drop zone TODO in `DesignerLayout`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea840bca083218a2c5bbe49fcb12d