### PR TITLE
Add submit handler in PreviewPane

### DIFF
--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -4,6 +4,12 @@ import { useDesigner } from '../context/DesignerContext';
 
 const PreviewPane = () => {
   const { schema, uiSchema, formData, setFormData } = useDesigner();
+
+  const handleSubmit = () => {
+    // TODO integrate more sophisticated submit handling in the final design
+    console.log('Submitted form data:', formData);
+  };
+
   return (
     <div className="preview-pane">
       <JsonForms
@@ -14,6 +20,10 @@ const PreviewPane = () => {
         cells={materialCells}
         onChange={({ data }) => setFormData(data)}
       />
+      {/* TODO replace this button with final submit UI */}
+      <button type="button" onClick={handleSubmit}>
+        Submit
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a Submit button to `PreviewPane`
- log form data on submit
- add TODO markers for future submit handling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcf1ef45883218ed533067a3b9777