### PR TITLE
Add FormsList placeholder and API TODOs

### DIFF
--- a/src/components/FormsList.tsx
+++ b/src/components/FormsList.tsx
@@ -1,0 +1,10 @@
+import { FC } from 'react';
+
+const FormsList: FC = () => {
+  // TODO fetch list of available forms via DesignerContext
+  // TODO implement search input to filter forms by name
+  // TODO add filters for tags or ownership
+  return <div>TODO: display list of forms</div>;
+};
+
+export default FormsList;

--- a/src/context/DesignerContext.tsx
+++ b/src/context/DesignerContext.tsx
@@ -2,6 +2,9 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 import { JsonSchema7 } from '@jsonforms/core';
 import { UISchemaElement } from '@jsonforms/core';
 
+// TODO load and persist forms via REST API, e.g. fetch('/api/forms')
+// This will allow sharing schemas between users
+
 export interface DesignerState {
   schema: JsonSchema7;
   uiSchema: UISchemaElement;
@@ -34,6 +37,8 @@ export const DesignerProvider = ({ children, initialSchema, initialUiSchema }: P
   const [uiSchema, setUiSchema] = useState<UISchemaElement>(initialUiSchema);
   const [formData, setFormData] = useState<any>({});
   const [errors, setErrors] = useState<any[]>([]);
+
+  // TODO replace local initialSchema with data loaded from the forms API
 
   return (
     <DesignerContext.Provider


### PR DESCRIPTION
## Summary
- add a new `FormsList` placeholder component
- document future forms API usage in `DesignerContext`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcfd23e508321bd61a2673b7a47a7