### PR TITLE
Add Next.js migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # JSON Forms React seed App
 
+<!--
+TODO: Migrate this project from Vite and Material UI to a Next.js
+setup using Tailwind CSS and Radix UI components (shadcn).
+Steps:
+1. Create a fresh Next.js project with `create-next-app`.
+2. Move the existing JSON Forms components and context into the new
+   application structure.
+3. Install and configure Tailwind CSS together with Radix UI/shadcn.
+4. Replace current MUI components with Radix/shadcn equivalents.
+5. Port Vite-specific configuration and scripts to Next.js pages and routing.
+-->
+
 This project demonstrates a small **JSON Forms Designer** built with React and Vite. It allows editing a JSON schema and UI schema side by side while a live preview renders the resulting form.
 
 It was originally based on `create-react-app` but has been migrated to Vite.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,10 @@
+// TODO: Transition this project from Vite and MUI to a Next.js setup
+// using Tailwind CSS and Radix UI/shadcn components.
+// 1. Create a new Next.js project via `create-next-app`.
+// 2. Move the existing components and context into the Next.js app.
+// 3. Install Tailwind CSS and Radix UI (shadcn/ui) packages.
+// 4. Replace Material UI components with their Radix/shadcn equivalents.
+// 5. Adapt Vite-specific configuration to Next.js pages and routing.
 import { createTheme, CssBaseline, ThemeProvider } from '@mui/material';
 import { createRoot } from 'react-dom/client';
 import App from './App';


### PR DESCRIPTION
## Summary
- outline migration plan in README
- note Next.js, Tailwind, and Radix UI migration in `src/main.tsx`

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fd0e747448321a7e046ee3ce3c26d