### PR TITLE
Add TODOs for Monaco schema registration

### DIFF
--- a/src/components/JsonSchemaEditor.tsx
+++ b/src/components/JsonSchemaEditor.tsx
@@ -12,6 +12,10 @@ const JsonSchemaEditor = () => {
     }
   };
 
+  // TODO: Register the current JSON schema with Monaco's JSON language service
+  // so that the editor provides auto-completion and error hints based on the
+  // schema definition.
+
   return (
     <Editor
       height="100%"

--- a/src/components/UiSchemaEditor.tsx
+++ b/src/components/UiSchemaEditor.tsx
@@ -12,6 +12,10 @@ const UiSchemaEditor = () => {
     }
   };
 
+  // TODO: Register the current UI schema with Monaco's JSON language service
+  // so that the editor can offer auto-completion and error hints based on the
+  // schema content.
+
   return (
     <Editor
       height="100%"


### PR DESCRIPTION
## Summary
- annotate JsonSchemaEditor and UiSchemaEditor with TODO comments
to register schemas with Monaco's JSON language service

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd1d18e5c8321a1804e41667c5fb3