### PR TITLE
Add docs for validation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ JSON Forms is rendered by importing and using the `JsonForms` component and dire
 ## Custom renderers
 
 Please see [our corresponding tutorial](https://jsonforms.io/docs/tutorial) on how to add custom renderers.
+
+## Future improvements
+
+- Introduce a `useValidationErrors` hook to share validation results between the
+  schema editors. This would allow the editors to display validation errors in
+  real time as users modify the JSON or UI schema.

--- a/src/context/DesignerContext.tsx
+++ b/src/context/DesignerContext.tsx
@@ -37,6 +37,8 @@ export const DesignerProvider = ({ children, initialSchema, initialUiSchema }: P
   const [uiSchema, setUiSchema] = useState<UISchemaElement>(initialUiSchema);
   const [formData, setFormData] = useState<any>({});
   const [errors, setErrors] = useState<any[]>([]);
+  // TODO: expose a `useValidationErrors` hook that updates this state in
+  // real time so the editors can highlight issues as the user types.
 
   // TODO replace local initialSchema with data loaded from the forms API
 

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -2,6 +2,9 @@ import Ajv from 'ajv';
 import { JsonSchema7, UISchemaElement } from '@jsonforms/core';
 
 const ajv = new Ajv({ allErrors: true });
+// TODO: Register common formats via `ajv-formats` and custom keywords needed
+// for the builder. Once we start surfacing validation errors to the user we
+// should also integrate `ajv-errors` for friendlier messages.
 
 export const validate = (schema: JsonSchema7, data: any) => {
   const validateFn = ajv.compile(schema);


### PR DESCRIPTION
## Summary
- note future realtime validation hook in README
- outline validation hook concept in context
- hint at AJV plugins for better error reporting

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd32ce0cc83218f1f7bdec3450db5