### PR TITLE
Add tailwind migration comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Steps:
 3. Install and configure Tailwind CSS together with Radix UI/shadcn.
 4. Replace current MUI components with Radix/shadcn equivalents.
 5. Port Vite-specific configuration and scripts to Next.js pages and routing.
+6. Remove the MUI theme setup in `src/main.tsx` and uninstall the `@mui/*`
+   packages.
+7. Replace the styles in `src/App.css` with Tailwind utility classes and
+   configure `tailwind.config.js` accordingly.
+8. Switch JSON Forms to use Tailwind-styled renderers or adapt the material
+   renderers to match the new design.
 -->
 
 This project demonstrates a small **JSON Forms Designer** built with React and Vite. It allows editing a JSON schema and UI schema side by side while a live preview renders the resulting form.

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,5 @@
+/* TODO: Replace this stylesheet with Tailwind CSS classes once the project
+   switches to Tailwind and shadcn/ui components. */
 html {
   font-size: 16px;
 }

--- a/src/components/DesignerLayout.tsx
+++ b/src/components/DesignerLayout.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace layout styling with Tailwind classes and use shadcn/ui
+// components after migrating away from Material UI.
 import { useState } from 'react';
 import SplitPane from 'react-split-pane-next';
 import Sidebar from './Sidebar';

--- a/src/components/DraggableControls.tsx
+++ b/src/components/DraggableControls.tsx
@@ -1,3 +1,5 @@
+// TODO: Once Tailwind is in place, style these controls with utility classes
+// and replace any remaining MUI components with shadcn/ui equivalents.
 import { useDraggable } from '@dnd-kit/core';
 
 const controls = ['Control', 'VerticalLayout', 'HorizontalLayout'];

--- a/src/components/FormsList.tsx
+++ b/src/components/FormsList.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace structural markup with shadcn/ui components and Tailwind
+// classes once Material UI is removed.
 import { FC } from 'react';
 
 const FormsList: FC = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,5 @@
+// TODO: Convert this header markup to use shadcn/ui components and Tailwind
+// utilities instead of plain classes.
 import { FC } from 'react';
 
 export const Header: FC = () => (

--- a/src/components/ImportExport.tsx
+++ b/src/components/ImportExport.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace the buttons and file input in this component with shadcn/ui
+// elements styled via Tailwind CSS.
 import { useDesigner } from '../context/DesignerContext';
 import { downloadJson } from '../utils/download';
 

--- a/src/components/JsonFormsDemo.tsx
+++ b/src/components/JsonFormsDemo.tsx
@@ -1,3 +1,5 @@
+// TODO: Swap Material UI components for shadcn/ui primitives and apply
+// Tailwind classes throughout this demo once Tailwind is integrated.
 import { FC, useMemo, useState } from 'react';
 import { JsonForms } from '@jsonforms/react';
 import Grid from '@mui/material/Grid';

--- a/src/components/JsonSchemaEditor.tsx
+++ b/src/components/JsonSchemaEditor.tsx
@@ -1,3 +1,5 @@
+// TODO: Style the editor container using Tailwind and replace any remaining MUI
+// wrappers with shadcn/ui components.
 import Editor from '@monaco-editor/react';
 import { useDesigner } from '../context/DesignerContext';
 

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace Material renderers with Tailwind-styled alternatives once
+// Tailwind and shadcn/ui are introduced.
 import { JsonForms } from '@jsonforms/react';
 import { materialRenderers, materialCells } from '@jsonforms/material-renderers';
 import { useDesigner } from '../context/DesignerContext';

--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace InputLabel and overall rating presentation with shadcn/ui
+// components and Tailwind styling.
 import { FC, useState } from 'react';
 import { InputLabel } from '@mui/material';
 

--- a/src/components/RatingControl.tsx
+++ b/src/components/RatingControl.tsx
@@ -1,3 +1,5 @@
+// TODO: Tailwind styling should replace inline styles here once shadcn/ui is
+// adopted across the project.
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { Rating } from './Rating';
 

--- a/src/components/SchemaTabs.tsx
+++ b/src/components/SchemaTabs.tsx
@@ -1,3 +1,5 @@
+// TODO: Convert these tabs to use shadcn/ui tab components and Tailwind
+// classes after the Material UI dependency is removed.
 import { useState } from 'react';
 import JsonSchemaEditor from './JsonSchemaEditor';
 import UiSchemaEditor from './UiSchemaEditor';

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,5 @@
+// TODO: Rebuild the sidebar using shadcn/ui primitives and Tailwind classes
+// for a consistent look once Material UI is replaced.
 import { useState } from 'react';
 import TemplateModal from './TemplateModal';
 import ImportExport from './ImportExport';

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace the StatusBar markup with shadcn/ui components and Tailwind
+// styling after migrating away from MUI.
 import { useDesigner } from '../context/DesignerContext';
 import { validate } from '../utils/validate';
 import { useEffect, useState } from 'react';

--- a/src/components/TemplateModal.tsx
+++ b/src/components/TemplateModal.tsx
@@ -1,3 +1,5 @@
+// TODO: Replace modal markup with shadcn/ui dialog components styled via
+// Tailwind.
 import { templates } from '../context/templates';
 import { useDesigner } from '../context/DesignerContext';
 

--- a/src/components/UiSchemaEditor.tsx
+++ b/src/components/UiSchemaEditor.tsx
@@ -1,3 +1,5 @@
+// TODO: Style the editor container with Tailwind and use shadcn/ui wrappers
+// after Material UI is removed from the project.
 import Editor from '@monaco-editor/react';
 import { useDesigner } from '../context/DesignerContext';
 


### PR DESCRIPTION
## Summary
- add migration steps to README
- note switch to Tailwind/shadcn in stylesheet
- annotate components with TODOs for Tailwind/shadcn transition

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd436fca883219165b531ca867293